### PR TITLE
JobsController: Accept base64 encoded payloads

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -105,6 +105,9 @@ class JobsController < ApplicationController
     begin
       str = params[:public_id]
       if Encryptor.enabled?
+        if use_base64?
+          str = Base64.decode64(str)
+        end
         str = Encryptor.decrypt(str)
       end
       array = str.split("-")
@@ -114,6 +117,7 @@ class JobsController < ApplicationController
       end
       @job = Job.find_by_public_id!(array[1])
     rescue Exception => e
+      puts e.message
       raise ActiveRecord::RecordNotFound.new('Not Found')
     end
 
@@ -131,6 +135,10 @@ class JobsController < ApplicationController
   end
 
   private
+
+  def use_base64?
+    params[:use_base64].to_s == "true"
+  end
 
   def job_params
     params.require(:job).permit(:name, :notifications, {notification_ids: []}, :frequency, :cron_expression, :buffer_time)

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -116,7 +116,7 @@ class JobsController < ApplicationController
         raise "Timestamp does not match"
       end
       @job = Job.find_by_public_id!(array[1])
-    rescue Exception => e
+    rescue StandardError => e
       puts e.message
       raise ActiveRecord::RecordNotFound.new('Not Found')
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Cronut::Application.routes.draw do
   resources :notifications
   resources :jobs
 
-  post 'ping/' => "jobs#ping"
+  post 'ping' => "jobs#ping"
+  post 'v2/ping' => "jobs#ping", defaults: {use_base64: true}
 
   root to: 'jobs#index'
   # The priority is based upon order of creation:

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -235,7 +235,7 @@ describe JobsController do
     end
   end
 
-  describe "GET ping" do
+  describe "POST ping" do
     before(:each) do
       invalid_basic_auth_login
       @job = IntervalJob.create!({:name => "Test IntervalJob", :frequency => 600})
@@ -295,6 +295,14 @@ describe JobsController do
     it "pings with valid token" do
       request.headers[JobsController::API_TOKEN_HEADER] = @token.token
       post :ping, {:public_id => Encryptor.encrypt(@str)}, valid_session
+      @job.reload
+      response.status.should eq 200
+      @job.last_successful_time.should_not be_nil
+    end
+
+    it "pings with valid token and a base64 encoded payload" do
+      request.headers[JobsController::API_TOKEN_HEADER] = @token.token
+      post :ping, {:public_id => Base64.strict_encode64(Encryptor.encrypt(@str)), use_base64: "true"}, valid_session
       @job.reload
       response.status.should eq 200
       @job.last_successful_time.should_not be_nil


### PR DESCRIPTION
Pings can now be base64 encoded. Simply base 64 encode the public id and
pass the `?use_base64=true` query string parameter.

This is useful when using RSA encryption and sending a publicly
encrypted payload.

Dealing with base64 encoded payload simplifies integration with other
platforms (such as the JVM) since we're not relying on some internal
ruby byte representation like the default implementation does.