### PR TITLE
Update sprockets (and sass, and uglifier)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,13 +14,9 @@ gem 'pg', '= 0.18.2'
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do
-  gem 'sass-rails',   '= 4.0.3'
-  gem 'coffee-rails', '= 4.0.1'
+  gem 'sass-rails'
 
-  # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-  # gem 'therubyracer', :platforms => :ruby
-
-  gem 'uglifier', '= 2.5.0'
+  gem 'uglifier'
 end
 
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,21 +41,14 @@ GEM
       activesupport
       tzinfo
     coderay (1.1.0)
-    coffee-rails (4.0.1)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.9.1.1)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
     erubis (2.7.0)
-    execjs (2.5.2)
+    execjs (2.7.0)
+    ffi (1.9.21)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    hike (1.2.3)
     i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     jquery-rails (4.0.4)
@@ -72,7 +65,6 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    multi_json (1.13.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pagerduty (2.0.1)
@@ -110,6 +102,9 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rspec-activemodel-mocks (1.0.1)
       activemodel (>= 3.0)
       activesupport (>= 3.0)
@@ -132,42 +127,43 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     rufus-scheduler (3.1.3)
-    sass (3.2.19)
-    sass-rails (4.0.3)
-      railties (>= 4.0.0, < 5.0)
-      sass (~> 3.2.0)
-      sprockets (~> 2.8, <= 2.11.0)
-      sprockets-rails (~> 2.0)
+    sass (3.5.5)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    sass-rails (5.0.7)
+      railties (>= 4.0.0, < 6)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
     slop (3.6.0)
     spring (1.3.6)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (2.11.0)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets (3.7.1)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.2.1)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     sqlite3 (1.3.10)
     thor (0.20.0)
     thread_safe (0.3.6)
-    tilt (1.4.1)
+    tilt (2.0.8)
     timecop (0.7.4)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (2.5.0)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    uglifier (3.0.4)
+      execjs (>= 0.3.0, < 3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   clockwork
-  coffee-rails (= 4.0.1)
   jquery-rails
   pagerduty
   pg (= 0.18.2)
@@ -176,12 +172,12 @@ DEPENDENCIES
   rspec-activemodel-mocks
   rspec-rails
   rufus-scheduler
-  sass-rails (= 4.0.3)
+  sass-rails
   spring
   spring-commands-rspec
   sqlite3
   timecop
-  uglifier (= 2.5.0)
+  uglifier
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/app/assets/javascripts/notifications.js.coffee
+++ b/app/assets/javascripts/notifications.js.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/


### PR DESCRIPTION
- Remove the pinned versions of sass-rails and uglifier
- Update sprockets to address vulnerability in 2.11.0
- Delete an empty .coffee file and drop the coffee gem